### PR TITLE
Make axum a dev-dependency instead of a dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ features = ["full"]
 
 [dependencies]
 http = "1.0.0"
-axum = "0.7.5"
 serde = "1.0.197"
 mime = "0.3.17"
 serde_yaml = { version = "0.9.27", optional = true }
@@ -40,6 +39,7 @@ thiserror = "1.0.58"
 bytes = "1.6.0"
 
 [dev-dependencies]
+axum = { version = "0.7.5", default-features = false }
 axum-test = "14.0.0"
 serde = { version = "1.0.197", features = ["derive"] }
 tokio = { version = "1.37.0", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ edition = "2021"
 features = ["full"]
 
 [dependencies]
+http = "1.0.0"
 axum = "0.7.5"
 serde = "1.0.197"
 mime = "0.3.17"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub mod yaml;
 #[cfg(feature = "cbor")]
 pub mod cbor;
 
-use axum::http::{header, HeaderMap};
+use http::{header, HeaderMap};
 use mime::Mime;
 
 #[cfg(feature = "msgpack")]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2,12 +2,11 @@
 //!
 
 pub use async_trait::async_trait;
-pub use axum::{
+pub use axum_core::{
     extract::{FromRequest, Request},
-    http,
-    response::{IntoResponse, Response},
-    routing, Router,
+    response::{IntoResponse, Response}
 };
+pub use http;
 pub use bytes::Bytes;
 pub use mime;
 pub use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -220,10 +219,10 @@ macro_rules! extractor {
         #[cfg(test)]
         mod $test {
             use super::*;
+            use axum::Router;
+            use axum::routing::{get, post};
             use $crate::macros::{
                 Bytes,
-                Router,
-                routing::{get, post},
                 {Deserialize, Serialize},
                 http::{
                     StatusCode,

--- a/src/rejection.rs
+++ b/src/rejection.rs
@@ -1,9 +1,9 @@
 //! # Rejection
 //!
 
-use axum::http::StatusCode;
 use axum_core::extract::rejection::BytesRejection;
 use axum_core::response::{IntoResponse, Response};
+use http::StatusCode;
 use std::fmt::Display;
 
 /// `Rejection` is an enumeration which describes different types of rejection


### PR DESCRIPTION
Most of the imports of `axum` are imports of code from other dependencies that `axum` re-exports, with the only imports of `axum` proper being in the module's tests. This PR peels the imports to directly reference re-exported dependencies and makes `axum` a dev-dependency instead, reducing the number of dependencies that need to be built on a `cargo check` from 72 to 36 and reducing the number of dependencies that other projects using this one need to pull in if they disable some default features of `axum`.